### PR TITLE
adding manual attribution method

### DIFF
--- a/src/UI/index.htm
+++ b/src/UI/index.htm
@@ -102,6 +102,13 @@
 				</div>
 			</div>
 
+			<div class="row">
+				<div class="input-field col s6">
+					<input id="attribution-box" type="text" value='Tiles © Insert Attribution Here'/>
+					<label for="attribution-box" class="active">Attribution:</label>
+				</div>
+			</div>			
+
 			<div class='center-align'>
 				<a class="waves-effect waves-light z-depth-0 btn-small orange darken-3" id='grid-preview-button'>Preview Grid</a>
 			</div>

--- a/src/UI/main.js
+++ b/src/UI/main.js
@@ -452,6 +452,7 @@ $(function() {
 		var outputType = $("#output-type").val();
 		var outputScale = $("#output-scale").val();
 		var source = $("#source-box").val()
+		var attribution = $("#attribution-box").val()
 
 		var bounds = getBounds();
 		var boundsArray = [bounds.getSouthWest().lng, bounds.getSouthWest().lat, bounds.getNorthEast().lng, bounds.getNorthEast().lat]
@@ -468,6 +469,7 @@ $(function() {
 		data.append('timestamp', timestamp)
 		data.append('bounds', boundsArray.join(","))
 		data.append('center', centerArray.join(","))
+		data.append('attribution', attribution)
 
 		var request = await $.ajax({
 			url: "/start-download",

--- a/src/mbtiles_writer.py
+++ b/src/mbtiles_writer.py
@@ -29,7 +29,7 @@ class MbtilesWriter:
 
 
 	@staticmethod
-	def addMetadata(lock, path, file, name, description, format, bounds, center, minZoom, maxZoom, profile="mercator", tileSize=256):
+	def addMetadata(attribution, lock, path, file, name, description, format, bounds, center, minZoom, maxZoom, profile="mercator", tileSize=256):
 
 		MbtilesWriter.ensureDirectory(lock, path)
 
@@ -64,7 +64,7 @@ class MbtilesWriter:
 				("scheme", "tms"), 
 				("generator", "Map Tiles Downloader via AliFlux"),
 				("type", "overlay"),
-				("attribution", "Map Tiles Downloader via AliFlux"),
+				("attribution", attribution),
 			])
 
 			connection.commit()

--- a/src/server.py
+++ b/src/server.py
@@ -138,6 +138,7 @@ class serverHandler(BaseHTTPRequestHandler):
 			boundsArray = map(float, bounds.split(","))
 			center = str(postvars['center'][0])
 			centerArray = map(float, center.split(","))
+			attribution = str(postvars['attribution'][0])
 
 			replaceMap = {
 				"timestamp": str(timestamp),
@@ -150,7 +151,7 @@ class serverHandler(BaseHTTPRequestHandler):
 
 			filePath = os.path.join("output", outputDirectory, outputFile)
 
-			self.writerByType(outputType).addMetadata(lock, os.path.join("output", outputDirectory), filePath, outputFile, "Map Tiles Downloader via AliFlux", "png", boundsArray, centerArray, minZoom, maxZoom, "mercator", 256 * outputScale)
+			self.writerByType(outputType).addMetadata(attribution, lock, os.path.join("output", outputDirectory), filePath, outputFile, "Map Tiles Downloader via AliFlux", "png", boundsArray, centerArray, minZoom, maxZoom, "mercator", 256 * outputScale)
 
 			result = {}
 			result["code"] = 200


### PR DESCRIPTION
Tile attribution can now be applied manually and added to the metadata of the output. Just apply text in Attribution field.